### PR TITLE
Speed up BSONEncoder by always appending without checking if the value is already contained

### DIFF
--- a/Sources/BSON/Codable/Encoding/BSONEncoder.swift
+++ b/Sources/BSON/Codable/Encoding/BSONEncoder.swift
@@ -163,7 +163,11 @@ fileprivate final class _BSONEncoder: Encoder, AnyBSONEncoder {
             return self.document?[converted(key.stringValue)]
         }
         set {
-            self.document?[converted(key.stringValue)] = newValue
+            if let newValue = newValue {
+                self.document?.appendValue(newValue, forKey: converted(key.stringValue))
+            } else {
+                self.document?.removeValue(forKey: converted(key.stringValue))
+            }
         }
     }
 
@@ -227,7 +231,7 @@ fileprivate struct _BSONKeyedEncodingContainer<Key: CodingKey> : KeyedEncodingCo
     mutating func encodeNil(forKey key: Key) throws {
         switch encoder.strategies.keyedNilEncodingStrategy {
         case .null:
-            encoder.document?[encoder.converted(key.stringValue)] = BSON.Null()
+            encoder.document?.appendValue(BSON.Null(), forKey: encoder.converted(key.stringValue)) 
         case .omitted:
             return
         }

--- a/Sources/BSON/Codable/Encoding/BSONEncoder.swift
+++ b/Sources/BSON/Codable/Encoding/BSONEncoder.swift
@@ -88,7 +88,8 @@ fileprivate final class _BSONEncoder: Encoder, AnyBSONEncoder {
             }
         }
         set {
-            target = .document(newValue ?? [:])
+            let document = newValue ?? [:]
+            target = .document(document)
         }
     }
     var primitive: Primitive? {
@@ -105,6 +106,10 @@ fileprivate final class _BSONEncoder: Encoder, AnyBSONEncoder {
         set {
             target = .primitive(newValue)
         }
+    }
+
+    deinit {
+        writer?(primitive)
     }
 
     // MARK: Configuration
@@ -210,7 +215,8 @@ fileprivate final class _BSONEncoder: Encoder, AnyBSONEncoder {
         )
 
         encoder.writer = { [weak self] primitive in
-            self?[key] = primitive
+            guard let self = self else { return }
+            self[key] = primitive
         }
 
         return encoder


### PR DESCRIPTION
This is technically not correct, but we can probably get away with this since Codable objects should only encode a key once